### PR TITLE
Add Zip in the needed php extensions list

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -19,7 +19,7 @@ Before creating your first Symfony application you must:
 
 * Install PHP 8.0.2 or higher and these PHP extensions (which are installed and
   enabled by default in most PHP 8 installations): `Ctype`_, `iconv`_,
-  `PCRE`_, `Session`_, `SimpleXML`_, and `Tokenizer`_;
+  `PCRE`_, `Session`_, `SimpleXML`_, `Tokenizer`_, and `Zip`_;
 
   * Note that all newer, released versions of PHP will be supported during the
     lifetime of each Symfony release (including new major versions).
@@ -330,3 +330,4 @@ Learn More
 .. _`Tokenizer`: https://www.php.net/book.tokenizer
 .. _`SimpleXML`: https://www.php.net/book.simplexml
 .. _`PCRE`: https://www.php.net/book.pcre
+.. _`Zip`: https://www.php.net/book.zip


### PR DESCRIPTION
It’s directly needed by Composer, so indirectly needed by Symfony (and maybe directly elsewhere).

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
